### PR TITLE
refs #35733 - absolute is needed in order for drupal to not call the …

### DIFF
--- a/modules/edw_document/edw_document.module
+++ b/modules/edw_document/edw_document.module
@@ -179,7 +179,10 @@ function edw_document_file_url_alter(&$uri) {
   $file = $documentManager->getFileByUri($uri);
   if ($file instanceof File) {
     $uuid = $file->uuid();
-    $url = Url::fromRoute('edw_document.serve_file', ['uuid' => $uuid], ['query' => ['filename' => $file->getFilename()]]);
+    $url = Url::fromRoute('edw_document.serve_file', ['uuid' => $uuid], [
+      'query' => ['filename' => $file->getFilename()],
+      'absolute' => TRUE,
+    ]);
     $uri = $url->toString();
   }
 }


### PR DESCRIPTION
…encode function